### PR TITLE
configuration via `env` and pretty-printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "site-builder"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "site-builder"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ What this tool does is it compiles source notes into longer files,
 leaving the links and the main notes intact if you want them.
 
 I hope that makes sense. I'll write a better readme soon :)
+
+## Usage
+The builder is configured through environment variables and does not accept any arguments.
+Right now there's no `--help` command, even!
+
+```shell
+export SITE_VAULT_PATH=/nix/persist/active-externalism/data
+export SITE_INCLUDE_SCOPES=public,website # comma-separated, spaces are ignored
+export SITE_OUTPUT_PATH=./dist
+
+site-builder
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,6 @@ fn concat_source_note(source_note: &Note, all_notes: &[Note]) -> Note {
         .map(|(link, note)| match note {
             Some(note) => {
                 println!("  - {}", &note.name.green());
-                // println!("├└─ `{}`", &note.name);
 
                 format!(
                     "{}\n\n{}\n\n---\n\n",
@@ -117,8 +116,6 @@ fn extract_link(line: &str) -> &str {
 }
 
 fn save_to_file(note: Note, workdir: &str) {
-    let _ = fs::create_dir("./dist");
-
     // TODO add frontmatter
 
     fs::write(format!("{}/{}.md", workdir, note.name), note.body).unwrap();


### PR DESCRIPTION
- add env variables for
  - source/vault directory
  - output directory
  - included scopes
- print the progress to the terminal

I know it needs some refactoring, but this version is just another prototype.